### PR TITLE
MON-5942: fix crash on sync

### DIFF
--- a/RCTAppleHealthKit/RTCAppleHealthKit+Methods_Statistics.m
+++ b/RCTAppleHealthKit/RTCAppleHealthKit+Methods_Statistics.m
@@ -733,7 +733,7 @@
     }
 
     NSMutableArray *samplesOutput = [NSMutableArray new];
-    HKSampleType *sample =[HKQuantityType quantityTypeForIdentifier:HKQuantityTypeIdentifierDietaryFiber];
+    HKSampleType *sample =[HKQuantityType quantityTypeForIdentifier:quantity];
 
     if ([sample isKindOfClass:[HKCharacteristicType class]]) {
         callback(@[RCTMakeError(@"RNHealth: Could not load data for HKCharacteristicType", nil, nil)]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-health",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "A React Native package to interact with Apple HealthKit",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Description

Fix crash on sync if permission for dietary fiber is allowed.

MON-5942

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
